### PR TITLE
Iterate over a generator instead of a list

### DIFF
--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     group = gl.groups.get(group)
 
     # Update each project in the group
-    for project in group.projects.list():
+    for project in group.projects.list(as_list=False):
         print("Project {group_name}/{project_name}".format(
                 group_name=group.name, project_name=project.name)
         )


### PR DESCRIPTION
The gitlab API is paged, meaning we only get 20 requests per call, but
python-gitlab can hide this for us and make a generator that calls
through all of the pages. This way we iterate over the entire collection
of projects within the group.