### PR TITLE
Add support for mass-enabling email notifications and for applying changes only to synced or non-synced packages

### DIFF
--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -36,6 +36,12 @@ def parse_args():
         choices=["True", "False"]
     )
 
+    parser.add_argument(
+        "--emails_enabled",
+        help="Enable/disable email notifications for the projects in group",
+        choices=["True", "False"]
+    )
+
     return parser.parse_args()
 
 
@@ -46,12 +52,17 @@ if __name__ == "__main__":
     visibility = args.visibility
     merge_requests_enabled = None
     issues_enabled = None
+    emails_disabled = None
 
     if args.merge_requests_enabled:
         merge_requests_enabled = args.merge_requests_enabled == "True"
 
     if args.issues_enabled:
         issues_enabled = args.issues_enabled == "True"
+
+    if args.emails_enabled:
+        emails_disabled = args.emails_enabled != "True"
+
     config_file = CONFIG_FILE
 
     # Read environment variable with config
@@ -88,4 +99,10 @@ if __name__ == "__main__":
                 old=savable_project.issues_enabled, new=issues_enabled)
             )
             savable_project.issues_enabled = issues_enabled
+
+        if emails_disabled is not None:
+            print("* emails_disabled: {old} -> {new}".format(
+                old=savable_project.emails_disabled, new=emails_disabled)
+            )
+            savable_project.emails_disabled = emails_disabled
         savable_project.save()

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -42,6 +42,12 @@ def parse_args():
         choices=["True", "False"]
     )
 
+    parser.add_argument(
+        "--dry-run",
+        help="Print the changes that would occur, but do not actually save them",
+        action=argparse.BooleanOptionalAction
+    )
+
     return parser.parse_args()
 
 
@@ -106,9 +112,10 @@ if __name__ == "__main__":
             )
             savable_project.emails_disabled = emails_disabled
 
-        while True:
-            try:
-                savable_project.save()
-                break
-            except requests.exceptions.ReadTimeout:
-                pass
+        if not args.dry_run:
+            while True:
+                try:
+                    savable_project.save()
+                    break
+                except requests.exceptions.ReadTimeout:
+                    pass

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -105,4 +105,10 @@ if __name__ == "__main__":
                 old=savable_project.emails_disabled, new=emails_disabled)
             )
             savable_project.emails_disabled = emails_disabled
-        savable_project.save()
+
+        while True:
+            try:
+                savable_project.save()
+                break
+            except requests.exceptions.ReadTimeout:
+                pass


### PR DESCRIPTION
For consistency, the CLI argument is --emails_enabled, but the API
option is emails_disabled.

Signed-off-by: Stephen Gallagher <sgallagh@redhat.com>