### PR TITLE
Merge features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,10 @@ dmypy.json
 
 # Configuration file
 python-gitlab.cfg
+
+# Temporary and backup files
+*~
+*.swp
+
+# PyCharm
+/.idea

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -33,6 +33,13 @@ def parse_args():
         help="Enable/disable merge requests for the projects in group",
         choices=["True", "False"]
     )
+
+    parser.add_argument(
+        "--merge_method",
+        help="Choose the merge method for MRs. See https://docs.gitlab.com/ee/api/projects.html#project-merge-method",
+        choices=["merge", "rebase_merge", "ff"]
+    )
+
     parser.add_argument(
         "--issues_enabled",
         help="Enable/disable issues for the projects in group",
@@ -72,12 +79,16 @@ if __name__ == "__main__":
     group = args.group
     visibility = args.visibility
     merge_requests_enabled = None
+    merge_method = None
     issues_enabled = None
     emails_disabled = None
     protect_branch = None
 
     if args.merge_requests_enabled:
         merge_requests_enabled = args.merge_requests_enabled == "True"
+
+    if args.merge_method:
+        merge_method = args.merge_method
 
     if args.issues_enabled:
         issues_enabled = args.issues_enabled == "True"
@@ -129,6 +140,12 @@ if __name__ == "__main__":
                 old=savable_project.merge_requests_enabled, new=merge_requests_enabled)
             )
             savable_project.merge_requests_enabled = merge_requests_enabled
+
+        if merge_method is not None:
+            print("* merge_method: {old} -> {new}".format(
+                old=savable_project.merge_method, new=merge_method)
+            )
+            savable_project.merge_method = merge_method
 
         if issues_enabled is not None:
             print("* issues_enabled: {old} -> {new}".format(

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -70,6 +70,11 @@ def parse_args():
         help="Branch to protect. Developers can merge, only maintainers and above can push"
     )
 
+    parser.add_argument(
+        "--ci_config_path",
+        help="The path to the Gitlab CI configuration."
+    )
+
     return parser.parse_args()
 
 
@@ -83,6 +88,7 @@ if __name__ == "__main__":
     issues_enabled = None
     emails_disabled = None
     protect_branch = None
+    ci_config_path = None
 
     if args.merge_requests_enabled:
         merge_requests_enabled = args.merge_requests_enabled == "True"
@@ -98,6 +104,9 @@ if __name__ == "__main__":
 
     if args.protect_branch:
         protect_branch = args.protect_branch
+
+    if args.ci_config_path:
+        ci_config_path = args.ci_config_path
 
     config_file = CONFIG_FILE
 
@@ -158,6 +167,12 @@ if __name__ == "__main__":
                 old=savable_project.emails_disabled, new=emails_disabled)
             )
             savable_project.emails_disabled = emails_disabled
+
+        if ci_config_path is not None:
+            print("* ci_config_path: {old} -> {new}".format(
+                old=savable_project.ci_config_path, new=ci_config_path)
+            )
+            savable_project.ci_config_path = ci_config_path
 
         if protect_branch is not None:
             branch_to_protect = savable_project.branches.get(protect_branch)

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -60,8 +60,7 @@ def parse_args():
 
     parser.add_argument(
         "--protect-branch",
-        help="Branch to protect. Developers can merge, only maintainers and above can push",
-        default="all"
+        help="Branch to protect. Developers can merge, only maintainers and above can push"
     )
 
     return parser.parse_args()


### PR DESCRIPTION
These patches add two additional feature settings to the group editor:

`--merge_method`: Sets the method used by the merge requests when the "merge" button is pressed. For CentOS Stream 9, we're going to want this to be `ff` (fast-forward merges only). Otherwise, the merge commit will fail the gitbz checks.

`--ci_config_path`: Defines the path to the out-of-repo configuration for the CI/CD pipelines. This will be needed to invoke the gitbz checks for all repos.

There are also two minor patches: 

*  An update to .gitignore to ignore PyCharm's `.idea` directory and some common vim suffixes for backup files
* The default value for `--protect-branch` was both wrong and potentially harmful. It has been dropped

attn: @bstinsonmhk @Zlopez 