### PR TITLE
Further enhancements

### DIFF
--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -209,13 +209,18 @@ if __name__ == "__main__":
             savable_project.only_allow_merge_if_pipeline_succeeds = only_allow_merge_if_pipeline_succeeds
 
         if protect_branch is not None:
-            branch_to_protect = savable_project.branches.get(protect_branch)
-            print("* protected_branches: {old.name} -> {new.name}".format(
-                old=branch_to_protect, new=branch_to_protect
-            ))
+            try:
+                branch_to_protect = savable_project.branches.get(protect_branch)
+                print("* protected_branches: {old.name} -> {new.name}".format(
+                    old=branch_to_protect, new=branch_to_protect
+                ))
 
-            if not args.dry_run:
-                branch_to_protect.protect(developers_can_push=False, developers_can_merge=True)
+                if not args.dry_run:
+                    branch_to_protect.protect(developers_can_push=False, developers_can_merge=True)
+            except gitlab.exceptions.GitlabGetError as e:
+                print("WARNING: {group_name}/{project_name} has no '{branch_name}' branch".format(
+                      group_name=group.name, project_name=project.name, branch_name=protect_branch)
+                )
 
 
         if not args.dry_run:

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -41,6 +41,12 @@ def parse_args():
     )
 
     parser.add_argument(
+        "--only_allow_merge_if_pipeline_succeeds",
+        help="Merge requests may not be merged until the pipeline passes",
+        choices=["True", "False"]
+    )
+
+    parser.add_argument(
         "--issues_enabled",
         help="Enable/disable issues for the projects in group",
         choices=["True", "False"]
@@ -89,6 +95,7 @@ if __name__ == "__main__":
     emails_disabled = None
     protect_branch = None
     ci_config_path = None
+    only_allow_merge_if_pipeline_succeeds = None
 
     if args.merge_requests_enabled:
         merge_requests_enabled = args.merge_requests_enabled == "True"
@@ -107,6 +114,9 @@ if __name__ == "__main__":
 
     if args.ci_config_path:
         ci_config_path = args.ci_config_path
+
+    if args.only_allow_merge_if_pipeline_succeeds:
+        only_allow_merge_if_pipeline_succeeds = args.only_allow_merge_if_pipeline_succeeds
 
     config_file = CONFIG_FILE
 
@@ -173,6 +183,13 @@ if __name__ == "__main__":
                 old=savable_project.ci_config_path, new=ci_config_path)
             )
             savable_project.ci_config_path = ci_config_path
+
+        if only_allow_merge_if_pipeline_succeeds is not None:
+            print("* only_allow_merge_if_pipeline_succeeds: {old} -> {new}".format(
+                old=savable_project.only_allow_merge_if_pipeline_succeeds,
+                new=only_allow_merge_if_pipeline_succeeds == "True")
+            )
+            savable_project.only_allow_merge_if_pipeline_succeeds = only_allow_merge_if_pipeline_succeeds
 
         if protect_branch is not None:
             branch_to_protect = savable_project.branches.get(protect_branch)

--- a/gitlab_group_editor.py
+++ b/gitlab_group_editor.py
@@ -81,6 +81,13 @@ def parse_args():
         help="The path to the Gitlab CI configuration."
     )
 
+    parser.add_argument(
+        "--c9s_setup",
+        help="Configure the selected projects with all of the standard CentOS Stream 9 settings. "
+             "Does not set visibility. Idempotent.",
+        action=argparse.BooleanOptionalAction
+    )
+
     return parser.parse_args()
 
 
@@ -117,6 +124,16 @@ if __name__ == "__main__":
 
     if args.only_allow_merge_if_pipeline_succeeds:
         only_allow_merge_if_pipeline_succeeds = args.only_allow_merge_if_pipeline_succeeds
+
+    if args.c9s_setup:
+        merge_request_enabled = True
+        merge_method = "ff"
+        issues_enabled = False
+        emails_disabled = False
+        protect_branch = "c9s"
+        ci_config_path = "global-tasks.yml@redhat/centos-stream/ci-cd/dist-git-gating-tests"
+        only_allow_merge_if_pipeline_succeeds = True
+
 
     config_file = CONFIG_FILE
 


### PR DESCRIPTION
Adds two new commands: `--only_allow_merge_if_pipeline_succeeds` (self-explanatory) and `--c9s_setup` which is a shorthand flag to set all of the fields (except visibility) to their expected values for live usage. Visibility must still be specified explicitly if it is being changed.

Also adds a try/catch block to not crash on repositories that do not have a `c9s` branch.